### PR TITLE
Q28: Reset index on train/test df's after sorting

### DIFF
--- a/gpu_bdb/queries/q28/gpu_bdb_query_28_dask_sql.py
+++ b/gpu_bdb/queries/q28/gpu_bdb_query_28_dask_sql.py
@@ -336,6 +336,7 @@ def main(data_dir, client, bc, config):
         ORDER BY pr_review_sk
     """
     test_data = bc.sql(query1)
+    test_data = test_data.reset_index(drop=True)
 
     # 90 % of data
     query2 = """
@@ -349,6 +350,7 @@ def main(data_dir, client, bc, config):
         ORDER BY pr_review_sk
     """
     train_data = bc.sql(query2)
+    train_data = train_data.reset_index(drop=True)
 
     final_data, acc, prec, cmat = post_etl_processing(
         client=client, train_data=train_data, test_data=test_data


### PR DESCRIPTION
Allows q28 to work with Dask-sql#229. 

Can get rid of the `reset_index` calls once the fix is incorporated in that PR. 