### PR TITLE
[REVIEW] Fix Q29 OOM issue

### DIFF
--- a/gpu_bdb/queries/q29/gpu_bdb_query_29_dask_sql.py
+++ b/gpu_bdb/queries/q29/gpu_bdb_query_29_dask_sql.py
@@ -52,17 +52,27 @@ def read_tables(data_dir, bc):
 
 def main(data_dir, client, bc, config):
     benchmark(read_tables, data_dir, bc, dask_profile=config["dask_profile"])
+    n_workers = len(client.scheduler_info()["workers"])
 
-    query_distinct = """
-        SELECT DISTINCT i_category_id, ws_order_number
+    join_query = """
+        -- Commented Distinct as we do it in drop_duplicates 
+        -- 553 M rows dont fit on single GPU (int32,int64 column)
+        -- TODO: Remove when we support Split Out
+        -- https://github.com/dask-contrib/dask-sql/issues/241
+
+        SELECT  i_category_id, ws_order_number
         FROM web_sales ws, item i
         WHERE ws.ws_item_sk = i.i_item_sk
         AND i.i_category_id IS NOT NULL
     """
-    result_distinct = bc.sql(query_distinct)
-
-    result_distinct = result_distinct.persist()
-    wait(result_distinct)
+    result = bc.sql(join_query)
+    
+    # Distinct Calculatiin
+    result_distinct = result.drop_duplicates(split_out=n_workers,ignore_index=True)
+    ## Remove the int64 index that was created
+    ## TODO Raise a issue for this
+    result_distinct = result_distinct.reset_index(drop=True)
+    
     bc.create_table('distinct_table', result_distinct, persist=False)
 
     query = f"""

--- a/gpu_bdb/queries/q29/gpu_bdb_query_29_dask_sql.py
+++ b/gpu_bdb/queries/q29/gpu_bdb_query_29_dask_sql.py
@@ -55,7 +55,7 @@ def main(data_dir, client, bc, config):
     n_workers = len(client.scheduler_info()["workers"])
 
     join_query = """
-        -- Commented Distinct as we do it in
+        -- Removed distinct as we do it in
         -- dask_cudf based drop_duplicates with split_out
         -- 553 M rows dont fit on single GPU (int32,int64 column)
         -- TODO: Remove when we support Split Out

--- a/gpu_bdb/queries/q29/gpu_bdb_query_29_dask_sql.py
+++ b/gpu_bdb/queries/q29/gpu_bdb_query_29_dask_sql.py
@@ -56,7 +56,7 @@ def main(data_dir, client, bc, config):
 
     join_query = """
         -- Commented Distinct as we do it in
-        -- dask_cudf based drop_duplicates with drop_duplicates
+        -- dask_cudf based drop_duplicates with split_out
         -- 553 M rows dont fit on single GPU (int32,int64 column)
         -- TODO: Remove when we support Split Out
         -- https://github.com/dask-contrib/dask-sql/issues/241


### PR DESCRIPTION
This PR adds a temporary work around to the memory issue in Q29 by adding `split_out` in `dask-cudf`.


Once we resolve https://github.com/dask-contrib/dask-sql/issues/241, we should be able to directly do this in `dask-sql` itself.  

CC: @ChrisJar  