### PR TITLE
[REVIEW] Fix order distribute by

### DIFF
--- a/gpu_bdb/queries/q02/gpu_bdb_query_02_dask_sql.py
+++ b/gpu_bdb/queries/q02/gpu_bdb_query_02_dask_sql.py
@@ -73,8 +73,6 @@ def main(data_dir, client, bc, config):
     )
     del wcs_result
 
-    session_df = session_df.persist()
-    wait(session_df)
     bc.create_table('session_df', session_df, persist=False)
 
     last_query = f"""

--- a/gpu_bdb/queries/q03/gpu_bdb_query_03_dask_sql.py
+++ b/gpu_bdb/queries/q03/gpu_bdb_query_03_dask_sql.py
@@ -189,8 +189,6 @@ def main(data_dir, client, bc, config):
         apply_find_items_viewed, item_mappings=item_df_filtered
     )
     
-    product_view_results = product_view_results.persist()
-    wait(product_view_results)
 
     bc.drop_table("item_df")
     del item_df

--- a/gpu_bdb/queries/q03/gpu_bdb_query_03_dask_sql.py
+++ b/gpu_bdb/queries/q03/gpu_bdb_query_03_dask_sql.py
@@ -207,7 +207,6 @@ def main(data_dir, client, bc, config):
         GROUP BY i_item_sk
         ORDER BY purchased_item, cnt desc, lastviewed_item
         LIMIT {q03_limit}
-        DISTRIBUTE BY lastviewed_item
     """
     result = bc.sql(last_query)
 

--- a/gpu_bdb/queries/q04/gpu_bdb_query_04_dask_sql.py
+++ b/gpu_bdb/queries/q04/gpu_bdb_query_04_dask_sql.py
@@ -155,7 +155,6 @@ def main(data_dir, client, bc, config):
         AND   c.wcs_web_page_sk IS NOT NULL
         AND   c.wcs_user_sk     IS NOT NULL
         AND   c.wcs_sales_sk    IS NULL --abandoned implies: no sale
-        ORDER BY wcs_user_sk, tstamp_inSec
         DISTRIBUTE BY wcs_user_sk
     """
     merged_df = bc.sql(query)

--- a/gpu_bdb/queries/q30/gpu_bdb_query_30_dask_sql.py
+++ b/gpu_bdb/queries/q30/gpu_bdb_query_30_dask_sql.py
@@ -88,7 +88,6 @@ def main(data_dir, client, bc, config):
         WHERE wcs.wcs_item_sk = i.i_item_sk
         AND i.i_category_id IS NOT NULL
         AND wcs.wcs_user_sk IS NOT NULL
-        ORDER BY wcs.wcs_user_sk, tstamp_inSec, i_category_id
         DISTRIBUTE BY wcs_user_sk
     """
     merged_df = bc.sql(query_2)

--- a/gpu_bdb/queries/q30/gpu_bdb_query_30_dask_sql.py
+++ b/gpu_bdb/queries/q30/gpu_bdb_query_30_dask_sql.py
@@ -42,22 +42,6 @@ q30_session_timeout_inSec = 3600
 # query output limit
 q30_limit = 40
 
-def start_local_cuda_cluster():
-    from dask_cuda import LocalCUDACluster
-    from distributed import Client
-    
-    cluster = LocalCUDACluster(local_directory='/data/vjawa/',
-                               device_memory_limit='18 GB',
-                               rmm_pool_size='29 GB',
-                               jit_unspill=True, 
-                               enable_nvlink=True)
-    client = Client(cluster)
-    return client
-
-    
-def start_dask_sql():
-    from dask_sql import Context
-    return Context()
 
 
 def read_tables(data_dir, bc, config):
@@ -143,6 +127,5 @@ def main(data_dir, client, bc, config):
 
 if __name__ == "__main__":
     config = gpubdb_argparser()
-    #client, bc = attach_to_cluster(config)
-    client, bc = start_local_cuda_cluster(), start_dask_sql()
+    client, bc = attach_to_cluster(config)
     run_query(config=config, client=client, query_func=main, blazing_context=bc)


### PR DESCRIPTION
This PR removes not required `order-by` / `distribute by` .

**Changes :**
1. `Query-02 `  : Remove not required persist
2. `Query-03`: Removing redundant distribute by on a single partition
3. `Query-04`: Removing redundant order by because we follow that with distribute by which  causes shuffling of rows so order by is redundant
4. `Query-30`: Removing redundant order by because we follow that with distribute by which  causes shuffling of rows so order by is redundant


Correctness Checks:
- [x] Query-02
- [x] Query-04
- [x] Query-04
- [x] Query-30


Benchmark Numbers:

**Query 2:**
- PR:  92 seconds
-  Mainline: 114 seconds

**Query 3:**
-   PR: 55.845
-   Mainline: 58.18 

**Query 4:**
-   PR: 22.8
-   Mainline: 80.49 seconds


**Query 30:**
-  PR: 42 seconds
-  Mainline: 137.17 seconds

CC:  @ChrisJar , @ayushdg
