### PR TITLE
Replace deprecated df.one_hot_encoder with cudf.get_dummies

### DIFF
--- a/gpu_bdb/queries/q05/gpu_bdb_query_05.py
+++ b/gpu_bdb/queries/q05/gpu_bdb_query_05.py
@@ -57,12 +57,12 @@ def get_groupby_results(file_list, item_df):
         keep_cols = ["wcs_user_sk", "i_category_id", "clicks_in_category"]
         wcs_ddf = wcs_ddf[keep_cols]
 
-        wcs_ddf = cudf.DataFrame.one_hot_encoding(
+        wcs_ddf = cudf.get_dummies(
             wcs_ddf,
-            column="i_category_id",
+            columns=["i_category_id"],
             prefix="clicks_in",
             prefix_sep="_",
-            cats=[i for i in range(1, 8)],
+            cats={"i_category_id":np.arange(1, 8, dtype="int32")},
             dtype=np.int8,
         )
         keep_cols = ["wcs_user_sk", "clicks_in_category"] + [

--- a/gpu_bdb/queries/q26/gpu_bdb_query_26.py
+++ b/gpu_bdb/queries/q26/gpu_bdb_query_26.py
@@ -28,6 +28,7 @@ from bdb_tools.q26_utils import (
     N_ITER,
     read_tables
 )
+import numpy as np
 from dask import delayed
 
 def agg_count_distinct(df, group_key, counted_key):
@@ -90,10 +91,10 @@ def main(client, config):
 
     # One-Hot-Encode i_class_id
     merged_ddf = merged_ddf.map_partitions(
-        cudf.DataFrame.one_hot_encoding,
-        column="i_class_id",
+        cudf.get_dummies,
+        columns=["i_class_id"],
         prefix="id",
-        cats=[i for i in range(1, 16)],
+        cats={"i_class_id": np.arange(1, 16, dtype="int32")},
         prefix_sep="",
         dtype="float32",
     )


### PR DESCRIPTION
Fixes rapidsai/gpu-bdb#229

Replaces deprecated in 21.12 and now removed in 22.02 `df.one_hot_encoder` method with `cudf.get_dummies`.

Verified that the results are identical at sf1k